### PR TITLE
basic public account links

### DIFF
--- a/intersect-core/src/api/domains.rs
+++ b/intersect-core/src/api/domains.rs
@@ -1,6 +1,8 @@
 use std::future::Future;
 
-use crate::models::{Access, Fragment, IndexMetadata, LinkEntry, Reference, Segment, Trace, UnlockedTrace};
+use crate::models::{
+    Access, Fragment, IndexMetadata, LinkEntry, Reference, Segment, Trace, UnlockedTrace,
+};
 use crate::record::Record;
 use crate::{veilid::get_crypto, FragmentRecord, Hash, IndexRecord, Secret, Shard};
 use crate::{Identity, IntersectError, VeilidRecordKey};

--- a/intersect-glasses/src/components/login.rs
+++ b/intersect-glasses/src/components/login.rs
@@ -1,5 +1,8 @@
 use anyhow::{anyhow, Context};
-use intersect_core::{models::{IndexMetadata, Segment}, Identity, PrivateKey, RootDomain, Shard};
+use intersect_core::{
+    models::{IndexMetadata, Segment},
+    Identity, PrivateKey, RootDomain, Shard,
+};
 use leptos::*;
 use leptos_router::State;
 
@@ -68,10 +71,9 @@ pub fn LoginForm() -> impl IntoView {
     };
 
     let create_account_root = make_action!(move |identity: &Identity| {
-        let root_name = Segment::new("account").unwrap();
         let account_name = Segment::new("anonymous").unwrap();
         let meta = IndexMetadata::new(identity.shard(), &account_name);
-        let _index = RootDomain::create_public(&identity, &root_name, &meta)
+        let _index = RootDomain::create_public(&identity, &Segment::new("account").unwrap(), &meta)
             .await
             .expect("failed to create account root index");
     });


### PR DESCRIPTION
should split up the account lookup code to a separate component / helper, but for now this will do.