### PR TITLE
Use pointer cursor for buttons

### DIFF
--- a/intersect-glasses/public/page.scss
+++ b/intersect-glasses/public/page.scss
@@ -66,6 +66,10 @@ a {
     }
 }
 
+button {
+    cursor: pointer;
+}
+
 button:not(.button-icon) {
     padding: 0.25rem;
     margin-bottom: 1em;


### PR DESCRIPTION
When working on other PRs, I noticed that anchor tags used the "hand-shaped" cursor, but buttons used the "arrow-shaped" cursor. This change applies the "hand-shaped" `pointer` cursor for buttons.