### PR TITLE
Upgrade to veilid 0.4.8

### DIFF
--- a/intersect-cli/Cargo.lock
+++ b/intersect-cli/Cargo.lock
@@ -4111,9 +4111,9 @@ dependencies = [
 
 [[package]]
 name = "veilid-core"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aed956d750cfa4bdaa3838fcb069bc6c07fda778f7a79ebb8b752eb1c73987ba"
+checksum = "709cbd186b9e94960c4d3957b40402ec166b8a262b156f9ce73a2da23f1bd099"
 dependencies = [
  "argon2",
  "async-tls",
@@ -4230,9 +4230,9 @@ dependencies = [
 
 [[package]]
 name = "veilid-tools"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f8ea5024138071fcb290441fa3cbb98d1ae37109764b65a48af4dadb8c1ae5"
+checksum = "a7a28dd110d1a605ce3fba3e08126df705b88c67bbda0970064e8aa886663d6f"
 dependencies = [
  "android_logger 0.13.3",
  "async-io",

--- a/intersect-core/Cargo.lock
+++ b/intersect-core/Cargo.lock
@@ -3832,9 +3832,9 @@ dependencies = [
 
 [[package]]
 name = "veilid-core"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aed956d750cfa4bdaa3838fcb069bc6c07fda778f7a79ebb8b752eb1c73987ba"
+checksum = "709cbd186b9e94960c4d3957b40402ec166b8a262b156f9ce73a2da23f1bd099"
 dependencies = [
  "argon2",
  "async-tls",
@@ -3951,9 +3951,9 @@ dependencies = [
 
 [[package]]
 name = "veilid-tools"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f8ea5024138071fcb290441fa3cbb98d1ae37109764b65a48af4dadb8c1ae5"
+checksum = "a7a28dd110d1a605ce3fba3e08126df705b88c67bbda0970064e8aa886663d6f"
 dependencies = [
  "android_logger 0.13.3",
  "async-io",

--- a/intersect-core/Cargo.toml
+++ b/intersect-core/Cargo.toml
@@ -12,10 +12,10 @@ rt-wasm = ["veilid-core/default-wasm", "veilid-tools/rt-wasm-bindgen"]
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 thiserror = "1.0"
-veilid-core = { version = "0.4.7", default-features = false }
+veilid-core = { version = "0.4.8", default-features = false }
 # veilid-core = { path = "../../veilid/veilid-core", default-features = false }
 # veilid-core = { git = "https://gitlab.com/evelyn-h/veilid.git", branch = "create-record-with-owner", default-features = false }
-veilid-tools = { version = "0.4.7", default-features = false }
+veilid-tools = { version = "0.4.8", default-features = false }
 # veilid-tools = { path = "../../veilid/veilid-tools", default-features = false }
 # veilid-tools = { git = "https://gitlab.com/evelyn-h/veilid.git", branch = "create-record-with-owner", default-features = false }
 binrw = "0.13.3"

--- a/intersect-core/src/record.rs
+++ b/intersect-core/src/record.rs
@@ -3,7 +3,7 @@ use itertools::Itertools;
 use thiserror::Error;
 use veilid_core::{
     DHTRecordDescriptor, DHTReportScope, DHTSchema, DHTSchemaSMPLMember, KeyPair, PublicKey,
-    ValueSubkey, ValueSubkeyRangeSet, VeilidAPIError,
+    SetDHTValueOptions, ValueSubkey, ValueSubkeyRangeSet, VeilidAPIError,
 };
 
 use crate::{
@@ -175,7 +175,10 @@ impl Record {
             *self.descriptor.key(),
             subkey,
             data,
-            Some(KeyPair::new(*self.shard.key(), *private_key.key())),
+            Some(SetDHTValueOptions {
+                writer: Some(KeyPair::new(*self.shard.key(), *private_key.key())),
+                ..Default::default()
+            }),
         )
         .await
         .map_err(|e| NetworkError::RecordWriteFailed(e))?;

--- a/intersect-core/src/veilid.rs
+++ b/intersect-core/src/veilid.rs
@@ -11,8 +11,7 @@ use veilid_core::{
 };
 use veilid_tools::Eventual;
 
-// Equivalent to the best crypto kind.
-pub const CRYPTO_KIND: CryptoKind = veilid_core::VALID_CRYPTO_KINDS[0];
+pub const CRYPTO_KIND: CryptoKind = veilid_core::CRYPTO_KIND_VLD0;
 
 pub async fn init() {
     VEILID.get_or_init(async { init_veilid().await }).await;

--- a/intersect-glasses/Cargo.lock
+++ b/intersect-glasses/Cargo.lock
@@ -4926,9 +4926,9 @@ dependencies = [
 
 [[package]]
 name = "veilid-core"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aed956d750cfa4bdaa3838fcb069bc6c07fda778f7a79ebb8b752eb1c73987ba"
+checksum = "709cbd186b9e94960c4d3957b40402ec166b8a262b156f9ce73a2da23f1bd099"
 dependencies = [
  "argon2",
  "async-tls",
@@ -5041,9 +5041,9 @@ dependencies = [
 
 [[package]]
 name = "veilid-tools"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f8ea5024138071fcb290441fa3cbb98d1ae37109764b65a48af4dadb8c1ae5"
+checksum = "a7a28dd110d1a605ce3fba3e08126df705b88c67bbda0970064e8aa886663d6f"
 dependencies = [
  "android_logger 0.13.3",
  "async-io",


### PR DESCRIPTION
Small PR to upgrade to veilid 0.4.8. This also switches back to using `CRYPTO_KIND_VLD0`, which had mistakenly been removed from veilid-core exports in an earlier version, and re-exported again in 0.4.8.